### PR TITLE
Allow users to pass along any parameters that socket.io may support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": ["airbnb"],
   "plugins": [
-    "add-module-exports"
+    "add-module-exports",
+    "transform-object-assign"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ render();
 ```
 
 - url: Any url for establishing a socket connection e.g: `http://localhost:9000`
-- opts: `optional` These are optional parameters allowed.
+- opts: `optional` These are the default optional parameters.
 Default parameters are:
 ```javascript
 auth: true,
@@ -60,10 +60,16 @@ reconnection: true,
 reconnectionDelay: 1000        
 ```
 
-You can ovveride them simply by passing for example:
+You can overide them simply by passing for example:
 
 ```javascript
 Resocket.connect('http://localhost:3000', {auth: false});
+```
+
+You can also extend the options object with socket.io accepted parameters:
+
+```javascript
+Resocket.connect('http://localhost:3000', {transports: ['polling']});
 ```
 
 **Note:** On passing `auth: false` Resocket won't allow a connection to be established. This is useful when you want to allow a connection to be only built after Login or some basic authentication.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ reconnection: true,
 reconnectionDelay: 1000        
 ```
 
-You can overide them simply by passing for example:
+You can override them simply by passing for example:
 
 ```javascript
 Resocket.connect('http://localhost:3000', {auth: false});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "mocha test/*.spec.js --compilers js:babel-register",
     "test:once": "nyc cover -x *.spec.js _mocha -- test/*.spec.js -R spec --compilers js:babel-register",
     "report-coverage": "./node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls",
-    "lint": "eslint --ext js,jsx src test",
+    "lint": "eslint --ext js,jsx src test --fix",
     "lint:examples": "eslint --ext js,jsx examples",
     "prebuild": "rimraf build",
     "build": "babel --copy-files --out-dir build src",
@@ -40,6 +40,7 @@
   "devDependencies": {
     "babel-cli": "6.16.0",
     "babel-plugin-add-module-exports": "0.2.1",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-airbnb": "2.1.1",
     "babel-register": "6.16.3",
     "chai": "3.5.0",

--- a/src/resocket.js
+++ b/src/resocket.js
@@ -17,14 +17,14 @@ const Resocket = {
   socket: null,
 };
 
-const SocketDefaults = {
-  auth: true,
-  reconnection: true,
-  reconnectionDelay: 1000,
-};
-
 function connect(params, opts) {
-  const defaults = Object.assign({}, SocketDefaults, opts);
+  const socketDefaults = {
+    auth: true,
+    reconnection: true,
+    reconnectionDelay: 1000,
+  };
+
+  const defaults = Object.assign({}, socketDefaults, opts);
 
   if (params && defaults.auth) {
     Resocket.socket = io.connect(params, defaults);

--- a/src/resocket.js
+++ b/src/resocket.js
@@ -17,9 +17,17 @@ const Resocket = {
   socket: null,
 };
 
-function connect(params, { auth = true, reconnection = true, reconnectionDelay = 1000 } = {}) {
-  if (params && auth) {
-    Resocket.socket = io.connect(params, { auth, reconnection, reconnectionDelay });
+const SocketDefaults = {
+  auth: true,
+  reconnection: true,
+  reconnectionDelay: 1000,
+};
+
+function connect(params, opts) {
+  const defaults = Object.assign({}, SocketDefaults, opts);
+
+  if (params && defaults.auth) {
+    Resocket.socket = io.connect(params, defaults);
     return Resocket.socket;
   }
 


### PR DESCRIPTION
Thanks for the library!

I think it makes sense to allow the passing of other optional socket parameters for two reasons:

1. Socket.io may update to allow more, important parameters in the future.
2. I personally had to pass along transport options but couldn't with the way it is currently written.